### PR TITLE
docs: Update DocC example to use configure(appId:)

### DIFF
--- a/Sources/CutiELink/CutiELink.docc/CutiELink.md
+++ b/Sources/CutiELink/CutiELink.docc/CutiELink.md
@@ -32,7 +32,7 @@ dependencies: [
 
 ### Configuration
 
-Configure once at app launch:
+Configure once at app launch with your App ID from the admin dashboard:
 
 ```swift
 import CutiELink
@@ -40,7 +40,7 @@ import CutiELink
 @main
 struct MyApp: App {
     init() {
-        CutiELink.configure(apiKey: "your-api-key")
+        CutiELink.configure(appId: "your_app_id")
     }
 
     var body: some Scene {
@@ -50,6 +50,8 @@ struct MyApp: App {
     }
 }
 ```
+
+Get your App ID from [admin.cuti-e.com](https://admin.cuti-e.com) under Settings > Apps.
 
 ### Open the Feedback App
 


### PR DESCRIPTION
## Summary
Update the DocC documentation example to use the new `configure(appId:)` method instead of the deprecated `configure(apiKey:)` method.

## Changes
- Replace `apiKey` with `appId` in the configuration example
- Add link to admin dashboard for getting the App ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)