### PR TITLE
ci: Migrate to self-hosted macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,44 +14,40 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: macos-14
+    runs-on: [self-hosted, macOS, ios]
     timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '15.0'
+      - name: Show Xcode version
+        run: xcodebuild -version
 
       - name: Build for iOS
         run: |
           xcodebuild build \
             -scheme CutiELink \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -skipPackagePluginValidation
 
   docs:
     name: Build Documentation
-    runs-on: macos-14
+    runs-on: [self-hosted, macOS, ios]
     timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '15.0'
+      - name: Show Xcode version
+        run: xcodebuild -version
 
       - name: Build DocC Documentation
         run: |
           xcodebuild docbuild \
             -scheme CutiELink \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
             -derivedDataPath .build
 
       # Note: Upload disabled - DocC generates filenames with colons (Swift function signatures)


### PR DESCRIPTION
## Summary
- Migrate CI workflow from `macos-14` to `[self-hosted, macOS, ios]`
- Remove setup-xcode step (use installed version on self-hosted runner)
- Update simulator destination to iPhone 16 Pro
- Applies to both build and docs jobs

## Motivation
Reduces GitHub Actions costs by using local Mac Mini runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)