### PR TITLE
fix(ci): Add checks:read permission to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+      checks: read
 
     steps:
       - name: Get PR number


### PR DESCRIPTION
Adds missing checks:read permission for github.rest.checks.listForRef() API call.