### PR TITLE
ci: Use self-hosted Linux runners instead of ubuntu-latest

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   auto-merge:
     name: Auto-merge Dependabot
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     if: github.actor == 'dependabot[bot]'
     permissions:
       pull-requests: write


### PR DESCRIPTION
Replace `ubuntu-latest` with `[self-hosted, Linux]` to force using self-hosted runners instead of GitHub-hosted runners.

This change:
- Reduces GitHub Actions costs by using self-hosted Ubuntu runners
- Applies to auto-merge.yml
- All Linux jobs will now run on self-hosted ARM64 runners