### PR TITLE
fix: Add thread safety to getDeviceId()

### DIFF
--- a/Sources/CutiELink/CutiELink.swift
+++ b/Sources/CutiELink/CutiELink.swift
@@ -22,6 +22,7 @@ public final class CutiELink {
     private var apiKey: String?
     private var appId: String?
     private var baseURL = "https://api.cuti-e.com"
+    private let deviceIdLock = NSLock()
 
     /// Configure CutiELink with your App ID (recommended)
     /// - Parameters:
@@ -179,6 +180,9 @@ public final class CutiELink {
     }
 
     private func getDeviceId() -> String {
+        deviceIdLock.lock()
+        defer { deviceIdLock.unlock() }
+
         let key = "com.cutie.link.deviceId"
         if let existing = UserDefaults.standard.string(forKey: key) {
             return existing


### PR DESCRIPTION
## Summary
- Added NSLock to synchronize access to UserDefaults in `getDeviceId()`
- Prevents race conditions where concurrent calls could generate multiple device IDs

Fixes #18

## Test plan
- [x] Build succeeds
- [ ] Concurrent calls to `openFeedbackApp()` return same device ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)