### PR TITLE
fix: Add HTTPS enforcement in configure()

### DIFF
--- a/Sources/CutiELink/CutiELink.swift
+++ b/Sources/CutiELink/CutiELink.swift
@@ -29,6 +29,12 @@ public final class CutiELink {
     ///   - appId: Your App ID from the admin dashboard (created in Settings > Apps)
     ///   - apiURL: Optional custom API URL (defaults to production)
     public static func configure(appId: String, apiURL: String = "https://api.cuti-e.com") {
+        // Enforce HTTPS for security and validate URL format
+        guard let url = URL(string: apiURL), url.scheme?.lowercased() == "https" else {
+            NSLog("[CutiELink] ERROR: apiURL must be a valid HTTPS URL. Configuration rejected.")
+            return
+        }
+
         shared.appId = appId
         shared.apiKey = nil
         shared.baseURL = apiURL


### PR DESCRIPTION
## Summary
- Reject configuration if `apiURL` doesn't use HTTPS
- Prevents accidental HTTP usage or URL injection in production

Fixes #17

## Test plan
- [x] Build succeeds
- [ ] `configure(appId: "x", apiURL: "http://...")` logs error and doesn't configure

🤖 Generated with [Claude Code](https://claude.com/claude-code)