### PR TITLE
ci: Add code coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
             -skipPackagePluginValidation
 
   test:
-    name: Test
+    name: Test with Coverage
     runs-on: [self-hosted, macOS, ios]
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -43,12 +43,43 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
-      - name: Run Tests
+      - name: Run Tests with Coverage
         run: |
           xcodebuild test \
             -scheme CutiELink \
             -destination 'platform=macOS,variant=Mac Catalyst' \
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult \
             -skipPackagePluginValidation
+
+      - name: Extract Coverage Report
+        run: |
+          # Extract coverage percentage
+          xcrun xccov view --report --only-targets TestResults.xcresult > coverage_report.txt
+          cat coverage_report.txt
+
+          # Extract overall coverage for CutiELink target (not CutiELinkTests)
+          COVERAGE=$(xcrun xccov view --report --only-targets TestResults.xcresult | grep -E '^[0-9]+\s+CutiELink\s' | awk '{print $(NF-1)}')
+          echo "## Code Coverage: $COVERAGE" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Coverage by File" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          xcrun xccov view --report TestResults.xcresult --files-for-target 'CutiELink' >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Check Coverage Threshold
+        run: |
+          # Extract coverage percentage (e.g., "11.31%" -> "11.31")
+          COVERAGE=$(xcrun xccov view --report --only-targets TestResults.xcresult | grep -E '^[0-9]+\s+CutiELink\s' | awk '{print $(NF-1)}' | tr -d '%')
+          echo "Coverage: ${COVERAGE}%"
+
+          # Warn if coverage is below 30% (informational, not blocking)
+          if [ -n "$COVERAGE" ]; then
+            COVERAGE_INT=${COVERAGE%.*}
+            if [ "$COVERAGE_INT" -lt 30 ]; then
+              echo "::warning::Code coverage is below 30% (${COVERAGE}%). Consider adding more tests."
+            fi
+          fi
 
   docs:
     name: Build Documentation


### PR DESCRIPTION
## Summary
- Enable code coverage collection in test job with `-enableCodeCoverage YES`
- Extract coverage report using `xcrun xccov` and add to GitHub Actions step summary
- Add warning threshold at 30% (informational, non-blocking)

## Changes
- Renamed "Test" job to "Test with Coverage"
- Increased timeout from 10 to 15 minutes (coverage takes longer)
- Added coverage extraction and reporting steps

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)