### PR TITLE
feat: Add SSL certificate pinning with expiry monitoring

### DIFF
--- a/.github/workflows/pin-expiry-check.yml
+++ b/.github/workflows/pin-expiry-check.yml
@@ -1,0 +1,93 @@
+name: Certificate Pin Expiry Check
+
+on:
+  schedule:
+    # Run monthly on the 1st at 00:00 UTC
+    - cron: '0 0 1 * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  check-expiry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check certificate pin expiry
+        id: expiry-check
+        run: |
+          # Certificate pins expire June 22, 2036
+          EXPIRY_DATE="2036-06-22"
+          EXPIRY_EPOCH=$(date -d "$EXPIRY_DATE" +%s)
+          NOW_EPOCH=$(date +%s)
+          DAYS_UNTIL=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 86400 ))
+
+          echo "days_until=$DAYS_UNTIL" >> $GITHUB_OUTPUT
+
+          if [ $DAYS_UNTIL -lt 0 ]; then
+            echo "::error::Certificate pins have EXPIRED! Immediate action required."
+            exit 1
+          elif [ $DAYS_UNTIL -lt 365 ]; then
+            echo "::warning::Certificate pins expire in $DAYS_UNTIL days. Plan SDK update."
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+          else
+            echo "Certificate pins valid for $DAYS_UNTIL more days (expires $EXPIRY_DATE)"
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create issue if expiring within 1 year
+        if: steps.expiry-check.outputs.needs_update == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const daysUntil = ${{ steps.expiry-check.outputs.days_until }};
+            const title = `Certificate pins expiring in ${daysUntil} days`;
+
+            // Check if issue already exists
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security,certificate-pinning'
+            });
+
+            const existingIssue = issues.data.find(i => i.title.includes('Certificate pins expiring'));
+
+            if (existingIssue) {
+              console.log(`Issue already exists: #${existingIssue.number}`);
+              // Update the existing issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: `Monthly check: Certificate pins expire in **${daysUntil} days** (June 22, 2036).`
+              });
+            } else {
+              // Create new issue
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: `## Certificate Pin Expiry Warning
+
+The SSL certificate pins in this SDK will expire on **June 22, 2036**.
+
+**Days remaining:** ${daysUntil}
+
+### Action Required
+
+1. Identify the new root CA certificates from Cloudflare/Google Trust Services
+2. Extract SPKI SHA-256 hashes for the new certificates
+3. Update \`CutiELinkCertificatePinning.swift\` with new hashes
+4. Test thoroughly on sandbox API
+5. Release new SDK version
+6. Notify all SDK users to update
+
+### Resources
+
+- [CERTIFICATE_PINNING.md](./CERTIFICATE_PINNING.md) - Update process documentation
+- [Google Trust Services](https://pki.goog/) - Root CA information
+
+This issue was automatically created by the monthly certificate expiry check.`,
+                labels: ['security', 'certificate-pinning', 'urgent']
+              });
+            }

--- a/CERTIFICATE_PINNING.md
+++ b/CERTIFICATE_PINNING.md
@@ -1,0 +1,180 @@
+# Certificate Pinning
+
+This SDK implements SSL certificate pinning to protect against man-in-the-middle attacks. This document explains the implementation and update process.
+
+## Current Configuration
+
+| Property | Value |
+|----------|-------|
+| Pinned CAs | Google Trust Services Root R1, R2, R3, R4 |
+| Intermediate | WE1 (Cloudflare) |
+| Expiry Date | **June 22, 2036** |
+| Monitoring | Automated CI check (monthly) |
+
+## How It Works
+
+The SDK pins to Google Trust Services root CAs, which are used by Cloudflare for our API endpoints. This is safer than pinning to leaf certificates because:
+
+1. Root CAs have long validity periods (10+ years)
+2. Cloudflare can rotate leaf certificates without breaking the SDK
+3. Users don't need to update the SDK for routine certificate renewals
+
+## Pinned Domains
+
+- `api.cuti-e.com` (production)
+- `cutie-worker-sandbox.invotekas.workers.dev` (sandbox)
+- `invotekas.workers.dev` (workers subdomain)
+
+## Monitoring
+
+### Automated CI Check
+
+A GitHub Actions workflow runs monthly to check pin expiry:
+
+- **Workflow:** `.github/workflows/pin-expiry-check.yml`
+- **Schedule:** 1st of each month at 00:00 UTC
+- **Action:** Creates/updates a GitHub issue when < 1 year remaining
+
+### Runtime Check
+
+The SDK logs a warning at initialization if pins are expiring soon:
+
+```
+[CutiELink] WARNING: Certificate pins expire in X days (June 22, 2036). Plan SDK update.
+```
+
+## When to Update
+
+Update certificate pins when:
+
+1. Current pins are within 1 year of expiry
+2. Cloudflare changes their certificate chain
+3. Google Trust Services issues new root CAs
+4. A pinned certificate is compromised (emergency)
+
+## Update Process
+
+### 1. Identify New Certificates
+
+Check which root CAs Cloudflare is currently using:
+
+```bash
+# Get the certificate chain from production API
+openssl s_client -connect api.cuti-e.com:443 -showcerts < /dev/null 2>/dev/null | \
+  openssl x509 -noout -issuer
+```
+
+Visit [Google Trust Services](https://pki.goog/) for current root CA information.
+
+### 2. Extract SPKI Hashes
+
+For each certificate in the chain:
+
+```bash
+# Download the certificate (example for GTS Root R1)
+curl -O https://pki.goog/repo/certs/gtsr1.der
+
+# Convert DER to PEM if needed
+openssl x509 -inform DER -in gtsr1.der -out gtsr1.pem
+
+# Extract SPKI hash
+openssl x509 -in gtsr1.pem -pubkey -noout | \
+  openssl pkey -pubin -outform DER | \
+  openssl dgst -sha256 -binary | \
+  base64
+```
+
+### 3. Update the SDK
+
+Edit `Sources/CutiELink/CutiELinkCertificatePinning.swift`:
+
+1. Add new hashes to `pinnedHashes`
+2. Update `pinExpiryDate` to the new expiry date
+3. Update comments with new certificate details
+
+```swift
+private let pinnedHashes: Set<String> = [
+    // NEW: GTS Root RX (add new certificates here)
+    "newHashHere=",
+    // Keep old hashes during transition period
+    "hxqRlPTu1bMS/0DITB1SSu0vd4u/8l8TjPgfaAp63Gc=",
+    // ...
+]
+
+private static let pinExpiryDate: Date = {
+    var components = DateComponents()
+    components.year = 2046  // Update to new expiry year
+    // ...
+}()
+```
+
+### 4. Test Thoroughly
+
+```bash
+# Build and run tests
+swift build
+swift test
+
+# Test against sandbox API
+# (Manual testing in a test app)
+
+# Test against production API
+# (Verify pinning works correctly)
+```
+
+### 5. Release New SDK Version
+
+1. Update version in `Package.swift` if needed
+2. Create PR with changes
+3. After merge, create a new release tag
+4. Update CHANGELOG.md
+
+### 6. Notify SDK Users
+
+- Create a GitHub release with update notes
+- Consider a deprecation warning in the old version
+- Allow transition period (keep old + new hashes)
+
+## Timeline
+
+| Date | Action |
+|------|--------|
+| Monthly | CI checks expiry, creates issue if < 1 year |
+| 1 year before | Start planning certificate update |
+| 6 months before | Release SDK with new pins |
+| 3 months before | Deprecation warnings for old SDK versions |
+| Expiry date | Old pins stop working |
+
+## Troubleshooting
+
+### Connection Failures After Update
+
+If users report connection failures after a certificate update:
+
+1. Verify the new hashes are correct
+2. Check if Cloudflare changed their certificate chain
+3. Temporarily add more root CA hashes to cover edge cases
+4. Release a hotfix SDK version
+
+### Extracting Hashes from Live Server
+
+```bash
+# Get all certificates in the chain
+echo | openssl s_client -connect api.cuti-e.com:443 -showcerts 2>/dev/null | \
+  awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/{ print }' > chain.pem
+
+# Split into individual certificates and hash each one
+```
+
+## Security Considerations
+
+- Never remove old hashes immediately; allow transition period
+- Keep at least 2-3 backup root CA hashes
+- Monitor for certificate chain changes proactively
+- Have an emergency update process ready
+
+## References
+
+- [OWASP Certificate Pinning](https://owasp.org/www-community/controls/Certificate_and_Public_Key_Pinning)
+- [Google Trust Services](https://pki.goog/)
+- [Cloudflare SSL/TLS](https://developers.cloudflare.com/ssl/)

--- a/Sources/CutiELink/CutiELink.swift
+++ b/Sources/CutiELink/CutiELink.swift
@@ -24,6 +24,11 @@ public final class CutiELink {
     private var baseURL = "https://api.cuti-e.com"
     private let deviceIdLock = NSLock()
 
+    /// URLSession with certificate pinning enabled
+    private lazy var pinnedSession: URLSession = {
+        CutiELinkCertificatePinning.shared.createPinnedSession()
+    }()
+
     /// Configure CutiELink with your App ID (recommended)
     /// - Parameters:
     ///   - appId: Your App ID from the admin dashboard (created in Settings > Apps)
@@ -163,7 +168,7 @@ public final class CutiELink {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await pinnedSession.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CutiELinkError.invalidResponse

--- a/Sources/CutiELink/CutiELinkCertificatePinning.swift
+++ b/Sources/CutiELink/CutiELinkCertificatePinning.swift
@@ -1,0 +1,235 @@
+import Foundation
+import CommonCrypto
+import Security
+
+/// Manages SSL certificate pinning for secure API communication
+/// Pins to Google Trust Services root CAs used by Cloudflare
+internal final class CutiELinkCertificatePinning: NSObject {
+
+    static let shared = CutiELinkCertificatePinning()
+
+    // MARK: - Expiry Monitoring
+
+    /// Certificate pin expiry date: June 22, 2036 00:00:00 UTC
+    /// This is when the Google Trust Services root CAs expire
+    private static let pinExpiryDate: Date = {
+        var components = DateComponents()
+        components.year = 2036
+        components.month = 6
+        components.day = 22
+        components.hour = 0
+        components.minute = 0
+        components.second = 0
+        components.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: components) ?? Date.distantFuture
+    }()
+
+    /// Number of days before expiry to start warning (1 year)
+    private static let expiryWarningThresholdDays: Int = 365
+
+    // MARK: - Certificate Pins
+
+    /// SPKI SHA-256 hashes for Google Trust Services Root CAs
+    /// These are stable root certificates that won't rotate with Cloudflare's leaf certs
+    /// All expire: June 22, 2036
+    private let pinnedHashes: Set<String> = [
+        // GTS Root R1 (RSA 4096-bit)
+        "hxqRlPTu1bMS/0DITB1SSu0vd4u/8l8TjPgfaAp63Gc=",
+        // GTS Root R2 (RSA 4096-bit)
+        "Vfd95BwDeSQo+NUYxVEEIlvkOlWY2SalKK1lPhzOx78=",
+        // GTS Root R3 (ECC 384-bit)
+        "QXnt2YHvdHR3tJYmQIr0Paosp6t/nggsEGD4QJZ3Q0g=",
+        // GTS Root R4 (ECC 384-bit) - Currently used by Cloudflare
+        "mEflZT5enoR1FuXLgYYGqnVEoZvmf9c2bVBpiOjYQ0c=",
+        // WE1 Intermediate (current Cloudflare intermediate)
+        "kIdp6NNEd8wsugYyyIYFsi1ylMCED3hZbSR8ZFsa/A4=",
+    ]
+
+    /// Domains that require certificate pinning
+    private let pinnedDomains: Set<String> = [
+        "api.cuti-e.com",
+        "cutie-worker-sandbox.invotekas.workers.dev",
+        "invotekas.workers.dev"
+    ]
+
+    private override init() {
+        super.init()
+        Self.checkPinExpiry()
+    }
+
+    // MARK: - Expiry Check
+
+    /// Check if certificate pins are approaching expiry and log a warning
+    /// Called automatically on initialization and can be called manually
+    static func checkPinExpiry() {
+        let now = Date()
+        let calendar = Calendar(identifier: .gregorian)
+
+        guard let daysUntilExpiry = calendar.dateComponents([.day], from: now, to: pinExpiryDate).day else {
+            return
+        }
+
+        if daysUntilExpiry < 0 {
+            NSLog("[CutiELink] CRITICAL: Certificate pins have EXPIRED! Update the SDK immediately.")
+        } else if daysUntilExpiry < expiryWarningThresholdDays {
+            NSLog("[CutiELink] WARNING: Certificate pins expire in %d days (June 22, 2036). Plan SDK update.", daysUntilExpiry)
+        }
+    }
+
+    /// Returns the number of days until certificate pins expire
+    /// Useful for monitoring and alerting
+    static func daysUntilPinExpiry() -> Int {
+        let calendar = Calendar(identifier: .gregorian)
+        return calendar.dateComponents([.day], from: Date(), to: pinExpiryDate).day ?? 0
+    }
+
+    /// Create a URLSession with certificate pinning enabled
+    func createPinnedSession(configuration: URLSessionConfiguration = .default) -> URLSession {
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+    }
+
+    /// Check if a host requires certificate pinning
+    func requiresPinning(for host: String) -> Bool {
+        return pinnedDomains.contains(host) ||
+               pinnedDomains.contains(where: { host.hasSuffix(".\($0)") })
+    }
+
+    /// Validate a certificate chain against pinned hashes
+    func validateCertificateChain(_ trust: SecTrust) -> Bool {
+        let certificateChain: [SecCertificate]
+
+        if #available(iOS 15.0, *) {
+            guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate] else {
+                return false
+            }
+            certificateChain = chain
+        } else {
+            // Fallback for iOS 14
+            let count = SecTrustGetCertificateCount(trust)
+            var chain: [SecCertificate] = []
+            for i in 0..<count {
+                if let cert = SecTrustGetCertificateAtIndex(trust, i) {
+                    chain.append(cert)
+                }
+            }
+            certificateChain = chain
+        }
+
+        for certificate in certificateChain {
+            if let publicKeyHash = getPublicKeyHash(for: certificate) {
+                if pinnedHashes.contains(publicKeyHash) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    /// Extract and hash the public key from a certificate
+    private func getPublicKeyHash(for certificate: SecCertificate) -> String? {
+        guard let publicKey = SecCertificateCopyKey(certificate) else {
+            return nil
+        }
+
+        var error: Unmanaged<CFError>?
+        guard let publicKeyData = SecKeyCopyExternalRepresentation(publicKey, &error) as Data? else {
+            return nil
+        }
+
+        guard let attributes = SecKeyCopyAttributes(publicKey) as? [String: Any],
+              let keyType = attributes[kSecAttrKeyType as String] as? String else {
+            return nil
+        }
+
+        let spkiHeader: Data
+        if keyType == (kSecAttrKeyTypeRSA as String) {
+            spkiHeader = Data([
+                0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09,
+                0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
+                0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00
+            ])
+        } else if keyType == (kSecAttrKeyTypeECSECPrimeRandom as String) {
+            let keySize = (attributes[kSecAttrKeySizeInBits as String] as? Int) ?? 256
+            if keySize == 256 {
+                spkiHeader = Data([
+                    0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86,
+                    0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a,
+                    0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03,
+                    0x42, 0x00
+                ])
+            } else if keySize == 384 {
+                spkiHeader = Data([
+                    0x30, 0x76, 0x30, 0x10, 0x06, 0x07, 0x2a, 0x86,
+                    0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x05, 0x2b,
+                    0x81, 0x04, 0x00, 0x22, 0x03, 0x62, 0x00
+                ])
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+
+        var spkiData = spkiHeader
+        spkiData.append(publicKeyData)
+
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        spkiData.withUnsafeBytes { buffer in
+            _ = CC_SHA256(buffer.baseAddress, CC_LONG(spkiData.count), &hash)
+        }
+
+        return Data(hash).base64EncodedString()
+    }
+}
+
+// MARK: - URLSessionDelegate
+
+extension CutiELinkCertificatePinning: URLSessionDelegate {
+
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        let host = challenge.protectionSpace.host
+
+        guard requiresPinning(for: host) else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+
+        var error: CFError?
+        let isServerTrusted = SecTrustEvaluateWithError(serverTrust, &error)
+
+        guard isServerTrusted else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+            return
+        }
+
+        if validateCertificateChain(serverTrust) {
+            let credential = URLCredential(trust: serverTrust)
+            completionHandler(.useCredential, credential)
+        } else {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+        }
+    }
+}
+
+extension CutiELinkCertificatePinning: URLSessionTaskDelegate {
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        urlSession(session, didReceive: challenge, completionHandler: completionHandler)
+    }
+}


### PR DESCRIPTION
## Summary

Adds SSL certificate pinning to ios-link-sdk for secure API communication, matching the security posture of ios-sdk.

- Adds `CutiELinkCertificatePinning` class with SPKI hash validation
- Pins to Google Trust Services root CAs (same as ios-sdk)
- Adds expiry monitoring with runtime warnings (< 1 year)
- Creates monthly CI workflow for automated expiry checks
- Adds `CERTIFICATE_PINNING.md` with update process documentation

## Changes

| File | Change |
|------|--------|
| `CutiELinkCertificatePinning.swift` | New file - certificate pinning implementation |
| `CutiELink.swift` | Use pinned URLSession instead of URLSession.shared |
| `.github/workflows/pin-expiry-check.yml` | Monthly CI check with auto-issue creation |
| `CERTIFICATE_PINNING.md` | Update process documentation |

## Security Notes

- Pins to same Google Trust Services root CAs as ios-sdk
- Certificate pins expire June 22, 2036
- Compatible with iOS 14+ (uses fallback API for older versions)
- Runtime warning logged if pins expire within 1 year

## Test Plan

- [x] `xcodebuild build` succeeds
- [x] All 38 tests pass
- [ ] CI workflow syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)