### PR TITLE
chore: Refresh workflow cache

### DIFF
--- a/.github/workflows/pin-expiry-check.yml
+++ b/.github/workflows/pin-expiry-check.yml
@@ -92,3 +92,4 @@ This issue was automatically created by the monthly certificate expiry check.`,
                 labels: ['security', 'certificate-pinning', 'urgent']
               });
             }
+


### PR DESCRIPTION
## Summary
- Add trailing newline to pin-expiry-check.yml to force GitHub to re-parse the workflow file

This refreshes GitHub's workflow cache so the `workflow_dispatch` trigger becomes available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)