### PR TITLE
fix(ci): use macOS runner for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: [self-hosted, Linux]
+    runs-on: [self-hosted, macOS, ios]
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
## Summary
- Change release-please workflow runner from `[self-hosted, Linux]` to `[self-hosted, macOS, ios]`
- SDK repos only have macOS self-hosted runners registered

## Test plan
- [ ] After merge, verify release-please runs successfully and creates a Release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)